### PR TITLE
Added missing export from `types.ts`

### DIFF
--- a/packages/core/lib/index.ts
+++ b/packages/core/lib/index.ts
@@ -2,3 +2,4 @@ export * from "./get-graphql-parameters";
 export * from "./process-request";
 export * from "./render-graphiql";
 export * from "./should-render-graphiql";
+export * from "./types";


### PR DESCRIPTION
Related: https://github.com/contrawork/graphql-helix/issues/16 