### PR TITLE
Expose `request` to contextFactory and `rootValueFactory`

### DIFF
--- a/packages/core/lib/process-request.ts
+++ b/packages/core/lib/process-request.ts
@@ -14,6 +14,7 @@ import {
 import { stopAsyncIteration, isAsyncIterable, isHttpMethod } from "./util";
 import { HttpError } from "./errors";
 import {
+  ExecutionContext,
   ExecutionPatchResult,
   MultipartResponse,
   ProcessRequestOptions,
@@ -143,7 +144,8 @@ export const processRequest = async <TContext = {}, TRootValue = {}>(
       }
 
       try {
-        const executionContext = {
+        const executionContext: ExecutionContext = {
+          request,
           document,
           operation,
           variables: variableValues,

--- a/packages/core/lib/types.ts
+++ b/packages/core/lib/types.ts
@@ -128,6 +128,7 @@ export interface FormatPayloadParams<TContext, TRootValue> {
 }
 
 export interface ExecutionContext {
+  request: Request;
   document: DocumentNode;
   operation: OperationDefinitionNode;
   variables?: { readonly [name: string]: unknown };


### PR DESCRIPTION
Related: https://github.com/contrawork/graphql-helix/issues/15