### PR TITLE
Allow `schema` option to be a Promise or a function

### DIFF
--- a/packages/core/lib/process-request.ts
+++ b/packages/core/lib/process-request.ts
@@ -75,12 +75,16 @@ export const processRequest = async <TContext = {}, TRootValue = {}>(
     query,
     request,
     rootValueFactory,
-    schema,
+    schema: sourceSchema,
     subscribe = defaultSubscribe,
     validate = defaultValidate,
     validationRules,
     variables,
   } = options;
+
+  const schema = await (typeof sourceSchema === "function"
+    ? sourceSchema(request)
+    : sourceSchema);
 
   let context: TContext | undefined;
   let rootValue: TRootValue | undefined;

--- a/packages/core/lib/types.ts
+++ b/packages/core/lib/types.ts
@@ -99,7 +99,10 @@ export interface ProcessRequestOptions<TContext, TRootValue> {
   /**
    * The GraphQL schema used to process the request.
    */
-  schema: GraphQLSchema;
+  schema:
+    | GraphQLSchema
+    | Promise<GraphQLSchema>
+    | ((request: Request) => Promise<GraphQLSchema> | GraphQLSchema);
   /**
    * An optional function which will be used to subscribe instead of default `subscribe` from `graphql-js`.
    */


### PR DESCRIPTION
Related: https://github.com/contrawork/graphql-helix/issues/17