### PR TITLE
Allow to provide all options externally using a function or async function

### DIFF
--- a/packages/core/lib/process-request.ts
+++ b/packages/core/lib/process-request.ts
@@ -15,6 +15,7 @@ import { stopAsyncIteration, isAsyncIterable, isHttpMethod } from "./util";
 import { HttpError } from "./errors";
 import {
   ExecutionPatchResult,
+  ExternalOptionsProviderFn,
   MultipartResponse,
   ProcessRequestOptions,
   ProcessRequestResult,
@@ -64,7 +65,9 @@ const getExecutableOperation = (
 };
 
 export const processRequest = async <TContext = {}, TRootValue = {}>(
-  options: ProcessRequestOptions<TContext, TRootValue>
+  options:
+    | ProcessRequestOptions<TContext, TRootValue>
+    | ExternalOptionsProviderFn<TContext, TRootValue>
 ): Promise<ProcessRequestResult<TContext, TRootValue>> => {
   const {
     contextFactory,
@@ -80,7 +83,7 @@ export const processRequest = async <TContext = {}, TRootValue = {}>(
     validate = defaultValidate,
     validationRules,
     variables,
-  } = options;
+  } = typeof options === "function" ? await options() : options;
 
   let context: TContext | undefined;
   let rootValue: TRootValue | undefined;

--- a/packages/core/lib/types.ts
+++ b/packages/core/lib/types.ts
@@ -58,6 +58,10 @@ export interface RenderGraphiQLOptions {
   subscriptionsEndpoint?: string;
 }
 
+export type ExternalOptionsProviderFn<TContext, TRootValue> = () =>
+  | ProcessRequestOptions<TContext, TRootValue>
+  | Promise<ProcessRequestOptions<TContext, TRootValue>>;
+
 export interface ProcessRequestOptions<TContext, TRootValue> {
   /**
    * A function whose return value is passed in as the `context` to `execute`.


### PR DESCRIPTION
Related: https://github.com/contrawork/graphql-helix/issues/14 , as suggested by @n1ru4l 