### PR TITLE
feat: upgrade meros

### DIFF
--- a/packages/graphiql/package.json
+++ b/packages/graphiql/package.json
@@ -23,7 +23,7 @@
     "graphql-language-service-interface": "^2.4.3",
     "graphql-ws": "^2.0.0",
     "lodash": "4.17.20",
-    "meros": "1.0.0-beta.9",
+    "meros": "1.1.4",
     "prop-types": "15.7.2",
     "react": "16.8.0",
     "react-dom": "16.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4541,10 +4541,10 @@ merge2@^1.2.3, merge2@^1.3.0:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-meros@1.0.0-beta.9:
-  version "1.0.0-beta.9"
-  resolved "https://registry.yarnpkg.com/meros/-/meros-1.0.0-beta.9.tgz#5e7d6bdaf0ccd6eb6592aed86b159be71805ad00"
-  integrity sha512-2pFgpBmypV/Ym2p24k/vHtjE40FQMsUZVKY+7VKLb9/hZELRozEIk0GfKWobS10qKOG1JONHaVV2fAcjmPugBQ==
+meros@1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/meros/-/meros-1.1.4.tgz#c17994d3133db8b23807f62bec7f0cb276cfd948"
+  integrity sha512-E9ZXfK9iQfG9s73ars9qvvvbSIkJZF5yOo9j4tcwM5tN8mUKfj/EKN5PzOr3ZH0y5wL7dLAHw3RVEfpQV9Q7VQ==
 
 methods@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
This upgrades meros, there is no material change to the final api here other than maybe also leveraging the new `multiple: true`.

As an aside note here; this _may_ suffer from the same issues outlined in https://github.com/graphql/graphiql/pull/1804 albeit not using dset—the issue about this not being a set, but rather an deepmerge at path problem.

Once a resolution is founded at graphiql, will update either this PR or raise a new one to rectify this.