### PR TITLE
Fix GraphiQL stringify variables

### DIFF
--- a/packages/graphiql/src/index.tsx
+++ b/packages/graphiql/src/index.tsx
@@ -69,7 +69,7 @@ const isAsyncIterable = (input: unknown): input is AsyncIterable<unknown> => {
 const buildGraphQLUrl = (
   baseUrl: string,
   query: string | undefined,
-  variables: string | undefined,
+  variables: string | object | undefined,
   operationName: string | undefined
 ): string => {
   const url = new URL(baseUrl);
@@ -82,7 +82,10 @@ const buildGraphQLUrl = (
     searchParams.set("operationName", operationName);
   }
   if (variables) {
-    searchParams.set("variables", variables);
+    searchParams.set(
+      "variables",
+      typeof variables === "object" ? JSON.stringify(variables) : variables
+    );
   }
 
   url.search = searchParams.toString();


### PR DESCRIPTION
While using the included GraphiQL I encountered this issue, locally added this code and it fixed it

![image](https://user-images.githubusercontent.com/8672915/116014618-27a2e900-a604-11eb-99dd-6e4ccb425c79.png)
