### PR TITLE
allow async parse function

### DIFF
--- a/packages/core/lib/process-request.ts
+++ b/packages/core/lib/process-request.ts
@@ -24,12 +24,21 @@ import {
 const parseQuery = (
   query: string | DocumentNode,
   parse: typeof defaultParse
-): DocumentNode => {
+): DocumentNode | Promise<DocumentNode> => {
   if (typeof query !== "string" && query.kind === "Document") {
     return query;
   }
   try {
-    return parse(query as string);
+    const parseResult = parse(query as string);
+
+    if (parseResult instanceof Promise) {
+      return parseResult.catch((syntaxError) => {
+        throw new HttpError(400, "GraphQL syntax error.", {
+          graphqlErrors: [syntaxError],
+        });
+      });
+    }
+    return parseResult;
   } catch (syntaxError) {
     throw new HttpError(400, "GraphQL syntax error.", {
       graphqlErrors: [syntaxError],
@@ -115,7 +124,7 @@ export const processRequest = async <TContext = {}, TRootValue = {}>(
         throw new HttpError(400, "Must provide query string.");
       }
 
-      document = parseQuery(query, parse);
+      document = await parseQuery(query, parse);
 
       validateDocument(schema, document, validate, validationRules);
 

--- a/packages/core/test/implementations/fastify_async.ts
+++ b/packages/core/test/implementations/fastify_async.ts
@@ -1,0 +1,132 @@
+import fastify, { RouteHandlerMethod } from "fastify";
+import { parse as graphqlParse } from "graphql";
+import {
+  getGraphQLParameters,
+  processRequest,
+  renderGraphiQL,
+  shouldRenderGraphiQL,
+} from "../../lib";
+import { schema } from "../schema";
+
+const sleep = (time: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, time));
+
+const graphqlHandler: RouteHandlerMethod = async (req, res) => {
+  const request = {
+    body: req.body,
+    headers: req.headers,
+    method: req.method,
+    query: req.query,
+  };
+  const { operationName, query, variables } = getGraphQLParameters(request);
+  const result = await processRequest({
+    operationName,
+    query,
+    variables,
+    request,
+    schema,
+    async parse(source, options) {
+      await sleep(50);
+      return graphqlParse(source, options);
+    },
+  });
+
+  if (result.type === "RESPONSE") {
+    result.headers.forEach(({ name, value }) => res.header(name, value));
+    res.status(result.status);
+    res.send(result.payload);
+  } else if (result.type === "PUSH") {
+    res.raw.writeHead(200, {
+      "Content-Type": "text/event-stream",
+      Connection: "keep-alive",
+      "Cache-Control": "no-cache",
+    });
+
+    req.raw.on("close", () => {
+      result.unsubscribe();
+    });
+
+    await result.subscribe((result) => {
+      res.raw.write(`data: ${JSON.stringify(result)}\n\n`);
+    });
+  } else {
+    res.raw.writeHead(200, {
+      Connection: "keep-alive",
+      "Content-Type": 'multipart/mixed; boundary="-"',
+      "Transfer-Encoding": "chunked",
+    });
+
+    req.raw.on("close", () => {
+      result.unsubscribe();
+    });
+
+    res.raw.write("---");
+
+    await result.subscribe((result) => {
+      const chunk = Buffer.from(JSON.stringify(result), "utf8");
+      const data = [
+        "",
+        "Content-Type: application/json; charset=utf-8",
+        "Content-Length: " + String(chunk.length),
+        "",
+        chunk,
+      ];
+
+      if (result.hasNext) {
+        data.push("---");
+      }
+
+      res.raw.write(data.join("\r\n"));
+    });
+
+    res.raw.write("\r\n-----\r\n");
+    res.raw.end();
+  }
+};
+
+const graphiqlHandler: RouteHandlerMethod = async (_req, res) => {
+  res.type("text/html");
+  res.send(renderGraphiQL({}));
+};
+
+const app = fastify();
+
+app.route({
+  method: ["GET", "POST", "PUT"],
+  url: "/graphql",
+  handler: graphqlHandler,
+});
+
+app.route({
+  method: ["GET"],
+  url: "/graphiql",
+  handler: graphiqlHandler,
+});
+
+app.route({
+  method: ["GET", "POST", "PUT"],
+  url: "/",
+  async handler(req, res) {
+    const request = {
+      body: req.body,
+      headers: req.headers,
+      method: req.method,
+      query: req.query,
+    };
+
+    if (shouldRenderGraphiQL(request)) {
+      await graphiqlHandler.call(this, req, res);
+    } else {
+      await graphqlHandler.call(this, req, res);
+    }
+  },
+});
+
+export default {
+  name: "async_fastify",
+  start: async (port: number) => {
+    await app.listen(port);
+
+    return async () => app.close();
+  },
+};

--- a/packages/core/test/implementations/index.ts
+++ b/packages/core/test/implementations/index.ts
@@ -1,5 +1,6 @@
 import express from "./express";
 import fastify from "./fastify";
+import asyncFastify from "./fastify_async";
 import koa from "./koa";
 
-export default [express, fastify, koa];
+export default [express, fastify, koa, asyncFastify];


### PR DESCRIPTION
I'm not completely sure in possible performance hits because of this, in theory, it could be possible to do something like this:

```ts
const parseResult = parseQuery(query, parse);
document = parseResult instanceof Promise ? await parseResult : parseResult;
```

And it's not going to await if the parse function is not async, but it will have an extra check in the process