### PR TITLE
Improve performance of isHttpMethod

### DIFF
--- a/packages/deno/util/is-http-method.ts
+++ b/packages/deno/util/is-http-method.ts
@@ -2,7 +2,5 @@ export const isHttpMethod = (
   target: "GET" | "POST",
   subject: string
 ): boolean => {
-  return (
-    subject.localeCompare(target, undefined, { sensitivity: "accent" }) === 0
-  );
+  return subject.toUpperCase() === target;
 };


### PR DESCRIPTION
Using `toUpperCase()` instead of `localeCompare()` makes the check 99.98% faster.
![Zrzut ekranu 2021-07-1 o 14 58 12](https://user-images.githubusercontent.com/8167190/124128443-17ccd880-da7d-11eb-9477-65c3e1ad9d8b.png)

Time spent at `isHttpMethod` was huge.
![Zrzut ekranu 2021-07-1 o 14 56 03](https://user-images.githubusercontent.com/8167190/124128448-19969c00-da7d-11eb-92c5-28004e03a0dc.png)
