### PR TITLE
handle graphql error as 200 response

### DIFF
--- a/packages/core/lib/index.ts
+++ b/packages/core/lib/index.ts
@@ -1,5 +1,6 @@
 export * from "./get-graphql-parameters";
 export * from "./process-request";
+export * from "./render-graphiql";
 export * from "./should-render-graphiql";
 export * from "./types";
 export * from "./errors";

--- a/packages/core/lib/index.ts
+++ b/packages/core/lib/index.ts
@@ -1,6 +1,5 @@
 export * from "./get-graphql-parameters";
 export * from "./process-request";
-export * from "./render-graphiql";
 export * from "./should-render-graphiql";
 export * from "./types";
 export * from "./errors";

--- a/packages/core/lib/process-request.ts
+++ b/packages/core/lib/process-request.ts
@@ -287,16 +287,16 @@ export const processRequest = async <TContext = {}, TRootValue = {}>(
             }
           );
         } else if (executionError instanceof HttpError) {
-            throw executionError;
-          } else {
-            throw new HttpError(
-              500,
-              "Unexpected error encountered while executing GraphQL request.",
-              {
-                graphqlErrors: [new GraphQLError(executionError.message)],
-              }
-            );
-          }
+          throw executionError;
+        } else {
+          throw new HttpError(
+            500,
+            "Unexpected error encountered while executing GraphQL request.",
+            {
+              graphqlErrors: [new GraphQLError(executionError.message)],
+            }
+          );
+        }
       }
     } catch (error) {
       const payload = {

--- a/packages/core/lib/process-request.ts
+++ b/packages/core/lib/process-request.ts
@@ -278,17 +278,25 @@ export const processRequest = async <TContext = {}, TRootValue = {}>(
           }
         }
       } catch (executionError) {
-        if (executionError instanceof HttpError) {
-          throw executionError;
-        } else {
+        if (executionError instanceof GraphQLError) {
           throw new HttpError(
-            500,
-            "Unexpected error encountered while executing GraphQL request.",
+            200,
+            "GraphQLError encountered white executed GraphQL request.",
             {
-              graphqlErrors: [new GraphQLError(executionError.message)],
+              graphqlErrors: [executionError],
             }
           );
-        }
+        } else if (executionError instanceof HttpError) {
+            throw executionError;
+          } else {
+            throw new HttpError(
+              500,
+              "Unexpected error encountered while executing GraphQL request.",
+              {
+                graphqlErrors: [new GraphQLError(executionError.message)],
+              }
+            );
+          }
       }
     } catch (error) {
       const payload = {


### PR DESCRIPTION
Currently executionError is handled 500 even if the error is an instance of GraphqlError. 
This pr changes that behavior: if the error is an instance of GraphqlError, send back as 200 response.
 
related: https://github.com/dotansimha/envelop/issues/606

@dotansimha Can you please take a look?