### PR TITLE
Fix getGraphQLParameters extensions for POST

### DIFF
--- a/packages/core/lib/get-graphql-parameters.ts
+++ b/packages/core/lib/get-graphql-parameters.ts
@@ -18,7 +18,7 @@ export const getGraphQLParameters = (request: Request): GraphQLParams => {
     operationName = body?.operationName;
     query = body?.query;
     variables = body?.variables;
-    extensions = body?.extension
+    extensions = body?.extensions;
   }
 
   return {


### PR DESCRIPTION
Thanks for looking at #250 quickly. Just spotted a small issue. The current code is missing the final `s` in `extensions` for `POST` requests.