### PR TITLE
fix: improve return type of async iterable while processing request

### DIFF
--- a/packages/core/lib/process-request.ts
+++ b/packages/core/lib/process-request.ts
@@ -21,6 +21,7 @@ import {
   ProcessRequestResult,
   Push,
   Request,
+  SubscribeFunction,
 } from "./types";
 import { getRankedResponseProtocols, RankedResponseProtocols } from "./util/get-ranked-response-protocols";
 
@@ -264,7 +265,7 @@ export const processRequest = async <TContext = {}, TRootValue = {}>(
           // Operations that use @defer, @stream and @live will return an `AsyncIterable` instead of an
           // execution result.
           if (isAsyncIterable<ExecutionPatchResult>(result)) {
-            const asyncSubscribe = async (onResult: Function) => {
+            const asyncSubscribe: SubscribeFunction<unknown> = async (onResult) => {
               for await (const payload of result) {
                 onResult(
                   formatPayload({

--- a/packages/core/lib/process-request.ts
+++ b/packages/core/lib/process-request.ts
@@ -19,6 +19,7 @@ import {
   MultipartResponse,
   ProcessRequestOptions,
   ProcessRequestResult,
+  Push,
   Request,
 } from "./types";
 import { getRankedResponseProtocols, RankedResponseProtocols } from "./util/get-ranked-response-protocols";
@@ -263,25 +264,39 @@ export const processRequest = async <TContext = {}, TRootValue = {}>(
           // Operations that use @defer, @stream and @live will return an `AsyncIterable` instead of an
           // execution result.
           if (isAsyncIterable<ExecutionPatchResult>(result)) {
-            return {
-              type: isHttpMethod("GET", request.method) ? "PUSH" : "MULTIPART_RESPONSE",
-              subscribe: async (onResult) => {
-                for await (const payload of result) {
-                  onResult(
-                    formatPayload({
-                      payload,
-                      context,
-                      rootValue,
-                      document,
-                      operation,
-                    })
-                  );
+            const asyncSubscribe = async (onResult: Function) => {
+              for await (const payload of result) {
+                onResult(
+                  formatPayload({
+                    payload,
+                    context,
+                    rootValue,
+                    document,
+                    operation,
+                  })
+                );
+              }
+            };
+
+            if (isHttpMethod("GET", request.method)) {
+              return {
+                type: 'PUSH',
+                subscribe: asyncSubscribe,
+                unsubscribe: () => {
+                  stopAsyncIteration(result);
                 }
-              },
-              unsubscribe: () => {
-                stopAsyncIteration(result);
-              },
-            } as MultipartResponse<TContext, TRootValue>;
+              } as Push<TContext, TRootValue>;
+            }
+            
+            if (isHttpMethod("POST", request.method)) {
+              return {
+                type: "MULTIPART_RESPONSE",
+                subscribe: asyncSubscribe,
+                unsubscribe: () => {
+                  stopAsyncIteration(result);
+                },
+              } as MultipartResponse<TContext, TRootValue>;
+            }
           } else {
             return {
               type: "RESPONSE",

--- a/packages/core/lib/types.ts
+++ b/packages/core/lib/types.ts
@@ -172,16 +172,19 @@ export interface Response<TContext, TRootValue> extends Result<TContext, TRootVa
   payload: ExecutionResult;
 }
 
+export type SubscribeFunction<TResult> = (onResult: (result: TResult) => void) => Promise<void>;
+
 export interface MultipartResponse<TContext, TRootValue> extends Result<TContext, TRootValue> {
   type: "MULTIPART_RESPONSE";
-  subscribe: (onResult: (result: ExecutionPatchResult) => void) => Promise<void>;
-  unsubscribe: () => void;
+  subscribe: SubscribeFunction<ExecutionPatchResult>;
+  unsubscribe: VoidFunction;
 }
 
+export type PushSubscribe = SubscribeFunction<ExecutionResult>;
 export interface Push<TContext, TRootValue> extends Result<TContext, TRootValue> {
   type: "PUSH";
-  subscribe: (onResult: (result: ExecutionResult) => void) => Promise<void>;
-  unsubscribe: () => void;
+  subscribe: SubscribeFunction<ExecutionResult>;
+  unsubscribe: VoidFunction;
 }
 
 export type ProcessRequestResult<TContext, TRootValue> =


### PR DESCRIPTION
Adding a conditional just to return `Push<T, V>` type too.