### PR TITLE
use body.extensions

### DIFF
--- a/packages/core/lib/get-graphql-parameters.ts
+++ b/packages/core/lib/get-graphql-parameters.ts
@@ -18,7 +18,7 @@ export const getGraphQLParameters = (request: Request): GraphQLParams => {
     operationName = body?.operationName;
     query = body?.query;
     variables = body?.variables;
-    extensions = body?.extension
+    extensions = body?.extensions
   }
 
   return {


### PR DESCRIPTION
when sending an extensions object with a get request the package expects an `extensions` in the query params, but when doing a post request it expects an object called `extension` in the payload



I believe this is a bug.

https://github.com/contra/graphql-helix/blob/f8e9b1acde278d3526bb43a6d573383d037e4993/packages/core/lib/get-graphql-parameters.ts#L12-L21



I opened this PR to fix it ツ



